### PR TITLE
Update build.gradle for using SonarQube

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,4 +4,5 @@ plugins {
     id 'com.android.library' version '8.0.0' apply false
     id 'org.jetbrains.kotlin.android' version '1.8.0' apply false
     id 'com.google.android.libraries.mapsplatform.secrets-gradle-plugin' version '2.0.1' apply false
+    id "org.sonarqube" version "4.2.1.3168"
 }


### PR DESCRIPTION
in order to use sonarqube in our static code analysis, we need to add that plugin 